### PR TITLE
Removes deprecated image and Maintainer command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM java:openjdk-8-jdk
-MAINTAINER LiveXP <dev@livexp.fr>
+FROM openjdk:8-jdk
+LABEL maintainer="LiveXP <dev@livexp.fr>"
 
 ENV ANDROID_SDK_VERSION 3859397
 ENV ANDROID_SDK_PATH /usr/local/bin/android-sdk
@@ -30,3 +30,4 @@ RUN docker-android-sdk-install "platform-tools" ${ANDROID_API_LEVELS}
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \
     apt-get clean
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:8-jdk
 LABEL maintainer="LiveXP <dev@livexp.fr>"
 
+ENV GRADLE_VERSION 4.2
 ENV ANDROID_SDK_VERSION 3859397
 ENV ANDROID_SDK_PATH /usr/local/bin/android-sdk
 ENV ANDROID_API_LEVELS "platforms;android-19" "platforms;android-20" "platforms;android-21" "platforms;android-22" "platforms;android-23" "platforms;android-24" "platforms;android-25" "platforms;android-26"
@@ -20,8 +21,13 @@ RUN wget https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_
     mv tools ${ANDROID_SDK_PATH} && \
     rm sdk-tools-linux-${ANDROID_SDK_VERSION}.zip
 
+RUN wget https://downloads.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip && \
+    mkdir /opt/gradle && \
+    unzip -d /opt/gradle gradle-${GRADLE_VERSION}-bin.zip && \
+    rm gradle-${GRADLE_VERSION}-bin.zip
+
 ENV ANDROID_HOME /usr/local/bin/android-sdk
-ENV PATH $PATH:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
+ENV PATH $PATH:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:/opt/gradle/gradle-${GRADLE_VERSION}/bin
 
 RUN mkdir ~/.android && touch ~/.android/repositories.cfg
 


### PR DESCRIPTION
Docker is deprecating the java image as well as the maintainer command. This should update the image to the more recent standard.